### PR TITLE
Default: do not index "properties" fields which may be indexing bombs

### DIFF
--- a/target_elasticsearch/sinks.py
+++ b/target_elasticsearch/sinks.py
@@ -283,6 +283,16 @@ class ElasticSink(BatchSink):
                                 }
                             },
                         ],
+                        # Some properties may be problematic - it's the case for fields called "properties",
+                        # which usually cause more problems than it solves -> disable dynamic mapping, and
+                        # store the field without indexing the contents
+                        "properties": {
+                            "properties": {
+                                "type": "object",
+                                "dynamic": "false",
+                                "enabled": False
+                            }
+                        }
                     }
 
 


### PR DESCRIPTION
Hotfix to avoid overindexing documents, such as Notion pages