### PR TITLE
Add gid to the list of potential main doc ids (used by Asana)

### DIFF
--- a/target_elasticsearch/sinks.py
+++ b/target_elasticsearch/sinks.py
@@ -491,7 +491,7 @@ class ElasticSink(BatchSink):
 
         # 2. Best effort to avoid duplicates:
         # In descending priority, try to match a field which looks like a primary key
-        id_fields = ["id", "ID", "Id", "accountId",
+        id_fields = ["id", "ID", "Id", "gid", "accountId",
                      "sha", "hash", "node_id", "idx", "key", "ts", "name"]
         for id_field in id_fields:
             if id_field in r:


### PR DESCRIPTION
Asana documents mostly use gid as their primary id field: add gid to the list of ES id field candidates.